### PR TITLE
Issue/158 bus auto scroll

### DIFF
--- a/lib/feature/my_page/feature/bus/bus.dart
+++ b/lib/feature/my_page/feature/bus/bus.dart
@@ -133,6 +133,7 @@ class BusScreen extends ConsumerWidget {
           Expanded(
             child: busData != null
                 ? ListView(
+                    controller: ScrollController(),
                     children: busData[fromToString]![busIsWeekday ? "weekday" : "holiday"]!
                         .map((busTrip) {
                       final funBusTripStop =
@@ -153,9 +154,9 @@ class BusScreen extends ConsumerWidget {
                       final now = busRefresh;
                       final nowDuration = Duration(hours: now.hour, minutes: now.minute);
                       final arriveAt = fromBusTripStop.time - nowDuration;
-                      if (arriveAt.isNegative) {
-                        return const SizedBox.shrink();
-                      }
+
+                      //return const SizedBox.shrink();
+                      //}
                       return InkWell(
                         onTap: () {
                           Navigator.push(

--- a/lib/feature/my_page/feature/bus/bus.dart
+++ b/lib/feature/my_page/feature/bus/bus.dart
@@ -144,7 +144,7 @@ class BusScreen extends ConsumerWidget {
       final position = box.localToGlobal(Offset.zero);
       scrollController.animateTo(
         scrollController.offset + position.dy - 300,
-        duration: const Duration(milliseconds: 1000),
+        duration: const Duration(milliseconds: 500),
         curve: Curves.easeInOut,
       );
       ref.read(busScrolledProvider.notifier).state = true;
@@ -158,6 +158,7 @@ class BusScreen extends ConsumerWidget {
           TextButton.icon(
             onPressed: () {
               ref.read(busIsWeekdayNotifier.notifier).change();
+              ref.read(busScrolledProvider.notifier).state = false;
             },
             icon: const Icon(
               Icons.swap_horiz_outlined,

--- a/lib/feature/my_page/feature/bus/controller/bus_controller.dart
+++ b/lib/feature/my_page/feature/bus/controller/bus_controller.dart
@@ -111,3 +111,5 @@ class BusIsWeekdayNotifier extends Notifier<bool> {
     state = !state;
   }
 }
+
+final busScrolledProvider = StateProvider<bool>((ref) => false);

--- a/lib/feature/my_page/feature/bus/widget/bus_card_home.dart
+++ b/lib/feature/my_page/feature/bus/widget/bus_card_home.dart
@@ -45,6 +45,7 @@ class BusCardHome extends ConsumerWidget {
         }
         return InkWell(
           onTap: () {
+            ref.read(busScrolledProvider.notifier).state = false;
             Navigator.push(
               context,
               PageRouteBuilder(


### PR DESCRIPTION
# 概要

- バスの時刻表を全表示して、開いたときに現在時刻のバスカードまで自動スクロール

# 関連する issue

- Close #158 

# 確認方法・見てほしいところ

1. ホームからバスのカードをタップする
2. バスがすべて表示されると共に現在時刻に近いバスまでスクロールする
3. 終発後はスクロールされない

# コメント

-
